### PR TITLE
Update C++20 calendar examples to match latest version of book

### DIFF
--- a/Library/createCalendar.cpp
+++ b/Library/createCalendar.cpp
@@ -1,70 +1,97 @@
 // createCalendar.cpp
 
+#include <chrono>
 #include <iostream>
-#include "date.h"
- 
+
 int main() {
 
     std::cout << '\n';
-    
-    using namespace date;
 
-    constexpr auto yearMonthDay{year(1940)/month(6)/day(26)};            
+    using namespace std::chrono_literals;
+
+    using std::chrono::last;
+
+    using std::chrono::year;
+    using std::chrono::month;
+    using std::chrono::day;
+
+    using std::chrono::year_month;
+    using std::chrono::year_month_day;
+    using std::chrono::year_month_day_last;
+    using std::chrono::year_month_weekday;
+    using std::chrono::year_month_weekday_last;
+    using std::chrono::month_weekday;
+    using std::chrono::month_weekday_last;
+    using std::chrono::month_day;
+    using std::chrono::month_day_last;
+    using std::chrono::weekday_last;
+    using std::chrono::weekday;
+
+    using std::chrono::January;
+    using std::chrono::February;
+    using std::chrono::June;
+    using std::chrono::March;
+    using std::chrono::October;
+
+    using std::chrono::Monday;
+    using std::chrono::Thursday;
+    using std::chrono::Sunday;
+
+    constexpr auto yearMonthDay{year(1940)/month(6)/day(26)};
     std::cout << yearMonthDay << " ";
-    std::cout << date::year_month_day(1940_y, June, 26_d) << '\n';  
+    std::cout << year_month_day(1940y, June, 26d) << '\n';
 
     std::cout << '\n';
 
-    constexpr auto yearMonthDayLast{year(2010)/March/last};             
+    constexpr auto yearMonthDayLast{year(2010)/March/last};
     std::cout << yearMonthDayLast << " ";
-    std::cout << date::year_month_day_last(2010_y, month_day_last(month(3))) << '\n';
+    std::cout << year_month_day_last(2010y, month_day_last(month(3))) << '\n';
 
-    constexpr auto yearMonthWeekday{year(2020)/March/Thursday[2]};       
+    constexpr auto yearMonthWeekday{year(2020)/March/Thursday[2]};
     std::cout << yearMonthWeekday << " ";
-    std::cout << date::year_month_weekday(2020_y, month(March), Thursday[2]) << '\n';
+    std::cout << year_month_weekday(2020y, month(March), Thursday[2]) << '\n';
 
-    constexpr auto yearMonthWeekdayLast{year(2010)/March/Monday[last]};  
+    constexpr auto yearMonthWeekdayLast{year(2010)/March/Monday[last]};
     std::cout << yearMonthWeekdayLast << " ";
-    std::cout << date::year_month_weekday_last(2010_y, month(March), 
-                                               weekday_last(Monday)) <<  '\n';
+    std::cout << year_month_weekday_last(2010y, month(March), weekday_last(Monday));
 
-    std::cout << '\n';
+    std::cout << "\n\n";
 
-    constexpr auto day_{day(19)};         
-    std::cout << day_  << " ";
-    std::cout << date::day(19) << '\n';
+    constexpr auto day_{day(19)};
+    std::cout << day_ << " ";
+    std::cout << day(19) << '\n';
 
-    constexpr auto month_{month(1)};       
-    std::cout << month_  << " ";
-    std::cout << date::month(1) << '\n';
+    constexpr auto month_{month(1)};
+    std::cout << month_ << " ";
+    std::cout << month(1) << '\n';
 
-    constexpr auto year_{year(1988)};     
-    std::cout << year_  << " ";
-    std::cout << date::year(1988) << '\n';
+    constexpr auto year_{year(1988)};
+    std::cout << year_ << " ";
+    std::cout << year(1988) << '\n';
 
     constexpr auto weekday_{weekday(5)};
-    std::cout << weekday_  << " ";
-    std::cout << date::weekday(5) << '\n';
- 
+    std::cout << weekday_ << " ";
+    std::cout << weekday(5) << '\n';
+
     constexpr auto yearMonth{year(1988)/1};
-    std::cout << yearMonth  << " ";
-    std::cout << date::year_month(year(1988), January) << '\n';
- 
+    std::cout << yearMonth << " ";
+    std::cout << year_month(year(1988), January) << '\n';
+
     constexpr auto monthDay{10/day(22)};
-    std::cout << monthDay <<  " ";
-    std::cout << date::month_day(October, day(22)) << '\n';
+    std::cout << monthDay << " ";
+    std::cout << month_day(October, day(22)) << '\n';
 
     constexpr auto monthDayLast{June/last};
     std::cout << monthDayLast << " ";
-    std::cout << date::month_day_last(month(6)) << '\n';
- 
+    std::cout << month_day_last(month(6)) << '\n';
+
     constexpr auto monthWeekday{2/Monday[3]};
     std::cout << monthWeekday << " ";
-    std::cout << date::month_weekday(February, Monday[3]) << '\n';
- 
+    std::cout << month_weekday(February, Monday[3]) << '\n';
+
     constexpr auto monthWeekDayLast{June/Sunday[last]};
     std::cout << monthWeekDayLast << " ";
-    std::cout << date::month_weekday_last(June, weekday_last(Sunday)) << '\n';
+    std::cout << month_weekday_last(June, weekday_last(Sunday)) << '\n';
 
     std::cout << '\n';
 

--- a/Library/cuteSyntax.cpp
+++ b/Library/cuteSyntax.cpp
@@ -1,24 +1,22 @@
 // cuteSyntax.cpp
 
+#include <chrono>
 #include <iostream>
-#include "date.h"
 
 int main() {
 
     std::cout << '\n';
 
-    using namespace date;
-
-    constexpr auto yearMonthDay{year(1966)/6/26};
+    constexpr auto yearMonthDay{std::chrono::year(1966)/6/26};
     std::cout << yearMonthDay << '\n';
 
-    constexpr auto dayMonthYear{day(26)/6/1966};
+    constexpr auto dayMonthYear{std::chrono::day(26)/6/1966};
     std::cout << dayMonthYear << '\n';
 
-    constexpr auto monthDayYear{month(6)/26/1966};
+    constexpr auto monthDayYear{std::chrono::month(6)/26/1966};
     std::cout << monthDayYear << '\n';
 
-    constexpr auto yearDayMonth{year(1966)/month(26)/6};  
+    constexpr auto yearDayMonth{std::chrono::year(1966)/std::chrono::month(26)/6};
     std::cout << yearDayMonth << '\n';
 
     std::cout << '\n';

--- a/Library/leapYear.cpp
+++ b/Library/leapYear.cpp
@@ -1,78 +1,75 @@
-//  leapYear.cpp
+// leapYear.cpp
 
+#include <chrono>
 #include <iostream>
-#include "date.h"
- 
+
 int main() {
 
     std::cout << std::boolalpha << '\n';
-    
-    using namespace date; 
 
-    std::cout << "Valid days" << '\n';               
-    day day31(31);
-    day day32 = day31 + days(1);
-    std::cout << "  day31: " << day31 << "; ";
-    std::cout << "day31.ok(): "  << day31.ok() << '\n';
-    std::cout << "  day32: " << day32 << "; ";
-    std::cout << "day32.ok(): "  << day32.ok() << '\n';
-   
+    std::cout << "Valid days" << '\n';
+    std::chrono::day day31(31);
+    std::chrono::day day32 = day31 + std::chrono::days(1);
+    std::cout << " day31: " << day31 << "; ";
+    std::cout << "day31.ok(): " << day31.ok() << '\n';
+    std::cout << " day32: " << day32 << "; ";
+    std::cout << "day32.ok(): " << day32.ok() << '\n';
 
     std::cout << '\n';
 
-    std::cout << "Valid months" << '\n';       
-    month month1(1);
-    month month0(0);
-    std::cout << "  month1: " << month1 << "; ";
-    std::cout << "month1.ok(): "  << month1.ok() << '\n';
-    std::cout << "  month0: " << month0 << "; ";
-    std::cout << "month0.ok(): "  << month0.ok() << '\n';
+    std::cout << "Valid months" << '\n';
+    std::chrono::month month1(1);
+    std::chrono::month month0(0);
+    std::cout << " month1: " << month1 << "; ";
+    std::cout << "month1.ok(): " << month1.ok() << '\n';
+    std::cout << " month0: " << month0 << "; ";
+    std::cout << "month0.ok(): " << month0.ok() << '\n';
 
     std::cout << '\n';
 
-    std::cout << "Valid years" << '\n';      
-    year year2020(2020);
-    year year32768(-32768);
-    std::cout << "  year2020: " << year2020 << "; ";
-    std::cout << "year2020.ok(): "  << year2020.ok() << '\n';
-    std::cout << "  year32768: " << year32768 << "; ";
-    std::cout << "year32768.ok(): "  << year32768.ok() << '\n';
+    std::cout << "Valid years" << '\n';
+    std::chrono::year year2020(2020);
+    std::chrono::year year32768(-32768);
+    std::cout << " year2020: " << year2020 << "; ";
+    std::cout << "year2020.ok(): " << year2020.ok() << '\n';
+    std::cout << " year32768: " << year32768 << "; ";
+    std::cout << "year32768.ok(): " << year32768.ok() << '\n';
 
     std::cout << '\n';
 
-    std::cout << "Leap Years"  << '\n';       
+    std::cout << "Leap Years" << '\n';
 
-    constexpr auto leapYear2016{year(2016)/2/29};
-    constexpr auto leapYear2020{year(2020)/2/29};
-    constexpr auto leapYear2024{year(2024)/2/29};
+    constexpr auto leapYear2016{std::chrono::year(2016)/2/29};
+    constexpr auto leapYear2020{std::chrono::year(2020)/2/29};
+    constexpr auto leapYear2024{std::chrono::year(2024)/2/29};
 
-    std::cout << "  leapYear2016.ok(): " << leapYear2016.ok() << '\n';
-    std::cout << "  leapYear2020.ok(): " << leapYear2020.ok() << '\n';
-    std::cout << "  leapYear2024.ok(): " << leapYear2024.ok() << '\n';
-
-    std::cout << '\n';
-
-     std::cout << "No Leap Years"  << '\n';   
-
-    constexpr auto leapYear2100{year(2100)/2/29};
-    constexpr auto leapYear2200{year(2200)/2/29};
-    constexpr auto leapYear2300{year(2300)/2/29};
-
-    std::cout << "  leapYear2100.ok(): " << leapYear2100.ok() << '\n';
-    std::cout << "  leapYear2200.ok(): " << leapYear2200.ok() << '\n';
-    std::cout << "  leapYear2300.ok(): " << leapYear2300.ok() << '\n';
+    std::cout << " leapYear2016.ok(): " << leapYear2016.ok() << '\n';
+    std::cout << " leapYear2020.ok(): " << leapYear2020.ok() << '\n';
+    std::cout << " leapYear2024.ok(): " << leapYear2024.ok() << '\n';
 
     std::cout << '\n';
 
-    std::cout << "Leap Years"  << '\n';      
+    std::cout << "No Leap Years" << '\n';
 
-    constexpr auto leapYear2000{year(2000)/2/29};
-    constexpr auto leapYear2400{year(2400)/2/29};
-    constexpr auto leapYear2800{year(2800)/2/29};
+    constexpr auto leapYear2100{std::chrono::year(2100)/2/29};
+    constexpr auto leapYear2200{std::chrono::year(2200)/2/29};
+    constexpr auto leapYear2300{std::chrono::year(2300)/2/29};
 
-    std::cout << "  leapYear2000.ok(): " << leapYear2000.ok() << '\n';
-    std::cout << "  leapYear2400.ok(): " << leapYear2400.ok() << '\n';
-    std::cout << "  leapYear2800.ok(): " << leapYear2800.ok() << '\n';
+    std::cout << " leapYear2100.ok(): " << leapYear2100.ok() << '\n';
+    std::cout << " leapYear2200.ok(): " << leapYear2200.ok() << '\n';
+    std::cout << " leapYear2300.ok(): " << leapYear2300.ok() << '\n';
+
+    std::cout << '\n';
+
+    std::cout << "Leap Years" << '\n';
+
+    constexpr auto leapYear2000{std::chrono::year(2000)/2/29};
+    constexpr auto leapYear2400{std::chrono::year(2400)/2/29};
+    constexpr auto leapYear2800{std::chrono::year(2800)/2/29};
+
+    std::cout << " leapYear2000.ok(): " << leapYear2000.ok() << '\n';
+    std::cout << " leapYear2400.ok(): " << leapYear2400.ok() << '\n';
+    std::cout << " leapYear2800.ok(): " << leapYear2800.ok() << '\n';
 
     std::cout << '\n';
 

--- a/Library/ordinalDate.cpp
+++ b/Library/ordinalDate.cpp
@@ -1,24 +1,39 @@
 // ordinalDate.cpp
 
-#include "date.h"
+#include <cassert>
+#include <chrono>
 #include <iomanip>
 #include <iostream>
 
-int main()
-{
-   using namespace date;
-   
-   const auto time = std::chrono::system_clock::now();
-   const auto daypoint = floor<days>(time);                   
-   const auto ymd = year_month_day{daypoint};         
-   
-   // calculating the year and the day of the year
-   const auto year = ymd.year();
-   const auto year_day = daypoint - sys_days{year/January/0}; 
-                                                              
-   std::cout << year << '-' << std::setfill('0') << std::setw(3) 
-             << year_day.count() << '\n';
-   
-   // inverse calculation and check
-   assert(ymd == year_month_day{sys_days{year/January/0} + year_day});
+int main() {
+
+    std::cout << '\n';
+
+    using std::chrono::system_clock;
+
+    using std::chrono::floor;
+
+    using std::chrono::days;
+
+    using std::chrono::January;
+
+    using std::chrono::year_month_day;
+    using std::chrono::sys_days;
+
+    const auto time = system_clock::now();
+    const auto daypoint = floor<days>(time);
+    const auto ymd = year_month_day{daypoint};
+
+    // calculating the year and the day of the year
+    const auto year = ymd.year();
+    const auto year_day = daypoint - sys_days{year/January/0};
+
+    std::cout << year << '-' << std::setfill('0') << std::setw(3)
+              << year_day.count() << '\n';
+
+    // inverse calculation and check
+    assert(ymd == year_month_day{sys_days{year/January/0} + year_day});
+
+    std::cout << '\n';
+
 }

--- a/Library/queryCalendarDates.cpp
+++ b/Library/queryCalendarDates.cpp
@@ -1,47 +1,57 @@
 // queryCalendarDates.cpp
 
-#include "date.h"
+#include <chrono>
 #include <iostream>
 
 int main() {
 
-    using namespace date;
-
     std::cout << '\n';
 
-    auto now = std::chrono::system_clock::now();              
-    std::cout << "The current time is: " << now << " UTC\n";       
+    using std::chrono::floor;
+
+    using std::chrono::January;
+
+    using std::chrono::years;
+    using std::chrono::days;
+    using std::chrono::hours;
+
+    using std::chrono::year_month_day;
+    using std::chrono::year_month_weekday;
+
+    using std::chrono::sys_days;
+
+    auto now = std::chrono::system_clock::now();
+    std::cout << "The current time is: " << now << " UTC\n";
     std::cout << "The current date is: " << floor<days>(now) << '\n';
-    std::cout << "The current date is: " << year_month_day{floor<days>(now)} 
+    std::cout << "The current date is: " << year_month_day{floor<days>(now)}
               << '\n';
-    std::cout << "The current date is: " << year_month_weekday{floor<days>(now)} 
+    std::cout << "The current date is: " << year_month_weekday{floor<days>(now)}
               << '\n';
 
     std::cout << '\n';
 
-    
-    auto currentDate = year_month_day(floor<days>(now));       
+    auto currentDate = year_month_day(floor<days>(now));
     auto currentYear = currentDate.year();
-    std::cout << "The current year is " << currentYear << '\n';    
+    std::cout << "The current year is " << currentYear << '\n';
     auto currentMonth = currentDate.month();
-    std::cout << "The current month is " << currentMonth << '\n'; 
+    std::cout << "The current month is " << currentMonth << '\n';
     auto currentDay = currentDate.day();
-    std::cout << "The current day is " << currentDay << '\n'; 
+    std::cout << "The current day is " << currentDay << '\n';
 
     std::cout << '\n';
-                                                               
-    auto hAfter = floor<std::chrono::hours>(now) - sys_days(January/1/currentYear); 
-    std::cout << "It has been " << hAfter << " since New Year!\n";  
-    auto nextYear = currentDate.year() + years(1);             
+
+    auto hAfter = floor<hours>(now) - sys_days(January/1/currentYear);
+    std::cout << "It has been " << hAfter << " since New Year!\n";
+    auto nextYear = currentDate.year() + years(1);
     auto nextNewYear = sys_days(January/1/nextYear);
-    auto hBefore =  sys_days(January/1/nextYear) - floor<std::chrono::hours>(now); 
+    auto hBefore = sys_days(January/1/nextYear) - floor<hours>(now);
     std::cout << "It is " << hBefore << " before New Year!\n";
 
     std::cout << '\n';
-                                                            
-    std::cout << "It has been " << floor<days>(hAfter) << " since New Year!\n";    
+
+    std::cout << "It has been " << floor<days>(hAfter) << " since New Year!\n";
     std::cout << "It is " << floor<days>(hBefore) << " before New Year!\n";
-    
+
     std::cout << '\n';
-    
+
 }

--- a/Library/sysDays.cpp
+++ b/Library/sysDays.cpp
@@ -1,34 +1,43 @@
 // sysDays.cpp
 
+#include <chrono>
 #include <iostream>
-#include "date.h"
- 
+
 int main() {
 
     std::cout << '\n';
-    
-    using namespace date;
+
+    using std::chrono::last;
+
+    using std::chrono::year;
+    using std::chrono::sys_days;
+
+    using std::chrono::March;
+    using std::chrono::February;
+
+    using std::chrono::Monday;
+    using std::chrono::Thursday;
 
     constexpr auto yearMonthDayLast{year(2010)/March/last};
-    std::cout << "sys_days(yearMonthDayLast): " 
-              << sys_days(yearMonthDayLast)  <<  '\n';
+    std::cout << "sys_days(yearMonthDayLast): "
+              << sys_days(yearMonthDayLast) << '\n';
 
     constexpr auto yearMonthWeekday{year(2020)/March/Thursday[2]};
-    std::cout << "sys_days(yearMonthWeekday): " 
-              <<  sys_days(yearMonthWeekday) << '\n';
+    std::cout << "sys_days(yearMonthWeekday): "
+              << sys_days(yearMonthWeekday) << '\n';
 
     constexpr auto yearMonthWeekdayLast{year(2010)/March/Monday[last]};
-    std::cout << "sys_days(yearMonthWeekdayLast): " 
+    std::cout << "sys_days(yearMonthWeekdayLast): "
               << sys_days(yearMonthWeekdayLast) << '\n';
 
     std::cout << '\n';
 
-    constexpr auto leapDate{year(2012)/February/last};               
+    constexpr auto leapDate{year(2012)/February/last};
     std::cout << "sys_days(leapDate): " << sys_days(leapDate) << '\n';
 
-    constexpr auto noLeapDate{year(2013)/February/last};             
+    constexpr auto noLeapDate{year(2013)/February/last};
     std::cout << "sys_day(noLeapDate): " << sys_days(noLeapDate) << '\n';
 
     std::cout << '\n';
 
-}   
+}

--- a/Library/timeOfDay.cpp
+++ b/Library/timeOfDay.cpp
@@ -1,38 +1,41 @@
 // timeOfDay.cpp
 
-#include "date.h"
+#include <chrono>
 #include <iostream>
 
 int main() {
-     using namespace date;                                                            
-     using namespace std::chrono_literals; 
 
-     std::cout << std::boolalpha << '\n';
-    
-     auto timeOfDay = date::hh_mm_ss(10.5h + 98min + 2020s + 0.5s);                    
-    
-     std::cout<< "timeOfDay: " << timeOfDay << '\n';                             
+    using namespace std::chrono_literals;
 
-     std::cout << '\n';
+    std::cout << std::boolalpha << '\n';
 
-     std::cout << "timeOfDay.hours(): " << timeOfDay.hours() << '\n';            
-     std::cout << "timeOfDay.minutes(): " << timeOfDay.minutes() << '\n';         
-     std::cout << "timeOfDay.seconds(): " << timeOfDay.seconds() << '\n';         
-     std::cout << "timeOfDay.subseconds(): " << timeOfDay.subseconds() << '\n';   
-     std::cout << "timeOfDay.to_duration(): " << timeOfDay.to_duration() << '\n'; 
+    auto timeOfDay = std::chrono::hh_mm_ss(10.5h + 98min + 2020s + 0.5s);
 
-     std::cout << '\n';
+    std::cout<< "timeOfDay: " << timeOfDay << '\n';
 
-     std::cout << "date::hh_mm_ss(45700.5s): " << date::hh_mm_ss(45700.5s) << '\n'; 
+    std::cout << '\n';
 
-     std::cout << '\n';
+    std::cout << "timeOfDay.hours(): " << timeOfDay.hours() << '\n';
+    std::cout << "timeOfDay.minutes(): " << timeOfDay.minutes() << '\n';
+    std::cout << "timeOfDay.seconds(): " << timeOfDay.seconds() << '\n';
+    std::cout << "timeOfDay.subseconds(): " << timeOfDay.subseconds() << '\n';
+    std::cout << "timeOfDay.to_duration(): " << timeOfDay.to_duration() << '\n';
 
-     std::cout << "date::is_am(5h): " << date::is_am(5h) << '\n';                     
-     std::cout << "date::is_am(15h): " << date::is_am(15h) << '\n';              
+    std::cout << '\n';
 
-     std::cout << '\n';
-     
-     std::cout << "date::make12(5h): " << date::make12(5h) << '\n';                 
-     std::cout << "date::make12(15h): " << date::make12(15h) << '\n';             
+    std::cout << "std::chrono::hh_mm_ss(45700.5s): "
+              << std::chrono::hh_mm_ss(45700.5s) << '\n';
+
+    std::cout << '\n';
+
+    std::cout << "std::chrono::is_am(5h): " << std::chrono::is_am(5h) << '\n';
+    std::cout << "std::chrono::is_am(15h): " << std::chrono::is_am(15h) << '\n';
+
+    std::cout << '\n';
+
+    std::cout << "std::chrono::make12(5h): " << std::chrono::make12(5h) << '\n';
+    std::cout << "std::chrono::make12(15h): " << std::chrono::make12(15h) << '\n';
+
+    std::cout << '\n';
 
 }

--- a/Library/weekdaysOfBirthdays.cpp
+++ b/Library/weekdaysOfBirthdays.cpp
@@ -1,20 +1,18 @@
 // weekdaysOfBirthdays.cpp
 
+#include <chrono>
 #include <cstdlib>
 #include <iostream>
-#include "date.h"
 
 int main() {
 
     std::cout << '\n';
 
-    using namespace date;
-
     int y;
     int m;
     int d;
 
-    std::cout << "Year: ";                          
+    std::cout << "Year: ";
     std::cin >> y;
     std::cout << "Month: ";
     std::cin >> m;
@@ -23,33 +21,35 @@ int main() {
 
     std::cout << '\n';
 
-    auto birthday = year(y)/month(m)/day(d);       
+    auto birthday = std::chrono::year(y)/std::chrono::month(m)/std::chrono::day(d);
 
-    if (not birthday.ok()) {                       
+    if (not birthday.ok()) {
         std::cout << birthday << '\n';
         std::exit(EXIT_FAILURE);
     }
 
     std::cout << "Birthday: " << birthday << '\n';
-    auto birthdayWeekday = year_month_weekday(birthday);   
+    auto birthdayWeekday = std::chrono::year_month_weekday(birthday);
     std::cout << "Weekday of birthday: " << birthdayWeekday.weekday() << '\n';
 
-    auto currentDate = year_month_day(floor<days>(std::chrono::system_clock::now()));  
+    auto currentDate = std::chrono::year_month_day(
+    std::chrono::floor<std::chrono::days>(std::chrono::system_clock::now()));
     auto currentYear = currentDate.year();
-    
-    auto age = (int)currentDate.year() - (int)birthday.year();  
+
+    auto age = (int)currentDate.year() - (int)birthday.year();
     std::cout << "Your age: " << age << '\n';
 
     std::cout << '\n';
 
-    std::cout << "Weekdays for your next 10 birthdays" << '\n';  
+    std::cout << "Weekdays for your next 10 birthdays" << '\n';
 
-    for (int i = 1, newYear = (int)currentYear; i <= 10;  ++i ) {  
-        std::cout << "  Age " <<  ++age << '\n';
-        auto newBirthday = year(++newYear)/month(m)/day(d);
-        std::cout << "    Birthday: " << newBirthday << '\n';
-        std::cout << "    Weekday of birthday: " 
-                  << year_month_weekday(newBirthday).weekday() << '\n';
+    for (int i = 1, newYear = (int)currentYear; i <= 10; ++i ) {
+        std::cout << " Age " << ++age << '\n';
+        auto newBirthday = std::chrono::year(++newYear)/
+        std::chrono::month(m)/std::chrono::day(d);
+        std::cout << " Birthday: " << newBirthday << '\n';
+        std::cout << " Weekday of birthday: "
+                  << std::chrono::year_month_weekday(newBirthday).weekday() << '\n';
     }
 
     std::cout << '\n';


### PR DESCRIPTION
Hi Rainer, I'm really enjoying your book so far, and I thought it might be of help to update the calendar code examples to replace the use of the `date.h` header with the `<chrono>` header.